### PR TITLE
Update default cache expiration property

### DIFF
--- a/backend/SelskiPazar.API/Configuration/CacheSettings.cs
+++ b/backend/SelskiPazar.API/Configuration/CacheSettings.cs
@@ -5,7 +5,7 @@
         public const string SectionName = "Cache";
 
         public string? RedisConnectionString { get; set; }
-        public int DefaultExpiryMinutes { get; set; } = 30;
+        public int DefaultExpirationMinutes { get; set; } = 30;
         public bool UseDistributedCache { get; set; } = false;
     }
 }


### PR DESCRIPTION
## Summary
- rename `DefaultExpiryMinutes` to `DefaultExpirationMinutes`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687541f00a7083299ee8768f363b009d